### PR TITLE
validate password in signup form

### DIFF
--- a/src/features/auth/api/sign-up.ts
+++ b/src/features/auth/api/sign-up.ts
@@ -6,7 +6,11 @@ import { AuthResponse } from '../types/auth';
 
 export const signUpSchema = z.object({
   email: z.string().email(),
-  password: z.string().min(1, 'Password is required'),
+  password: z.string()
+    .min(6, 'Password must contain at least 6 characters')
+    .regex(/[^\w\s]/, 'Password must contain at least one non-alphanumeric character')
+    .regex(/[\d]/, 'Password must contain at least one digit')
+    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter'),
   oncToken: z.string(),
   name: z.string(),
 });


### PR DESCRIPTION
Add checks for pasword field in the user signup modal so an invalid password does not result in 400 error

closes #56 